### PR TITLE
Fix overlay not visible

### DIFF
--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -67,7 +67,7 @@ class PlayerWithControls extends StatelessWidget {
                   ),
                   child: const DecoratedBox(
                     decoration: BoxDecoration(color: Colors.black54),
-                    child: SizedBox(),
+                    child: SizedBox.expand(),
                   ),
                 ),
               ),


### PR DESCRIPTION
Causes usability issues, when controls are similar color as the video

Broken since v1.3.5

**master:**
<img width="482" alt="currently" src="https://user-images.githubusercontent.com/10659247/234482837-94a90b01-e5d8-42fd-a314-67fa0641ad1e.png">

**fix/overlay:**
<img width="482" alt="fixed" src="https://user-images.githubusercontent.com/10659247/234482947-44ece8d8-45c2-4dec-bd0c-cf19d2655ea8.png">

